### PR TITLE
Replaces email service with SESEmailService provided by PR in KicData

### DIFF
--- a/Controllers/ApiController.cs
+++ b/Controllers/ApiController.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using Hangfire;
+using KiCData.Models.WebModels;
+using KiCData.Services;
+using Microsoft.AspNetCore.Mvc;
 
 namespace KiCWeb.Controllers
 {
@@ -7,10 +10,14 @@ namespace KiCWeb.Controllers
     public class ApiController : Controller
     {
         private readonly IConfigurationRoot _config;
+        private readonly IEmailService _emailService;
+        private readonly IBackgroundJobClient _jobClient;
 
-        public ApiController(IConfigurationRoot config)
+        public ApiController(IConfigurationRoot config, IEmailService emailService, IBackgroundJobClient  backgroundJobClient)
         {
             _config = config;
+            _emailService = emailService;
+            _jobClient = backgroundJobClient;
         }
 
         [HttpGet]
@@ -63,5 +70,23 @@ namespace KiCWeb.Controllers
 
             return File(fileBytes, "img/png");
         }
+
+        /*
+        [Route("SendEmail")]
+        [HttpPost]
+        public string SendEmail(string to, string subject, string body)
+        {
+            var msg = new FormMessage
+            {
+                To = [to],
+                From = _config["Email Addresses:From"],
+                Sender = _config["Email Addresses:From"],
+                Subject = subject,
+                Html = body
+            };
+            _jobClient.Enqueue(() => _emailService.SendEmail(msg));
+            return "OK";
+        }
+        */
     }
 }

--- a/Controllers/GenController.cs
+++ b/Controllers/GenController.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.EntityFrameworkCore;
 using System.Diagnostics;
+using Hangfire;
 using KiCData;
 using KiCData.Services;
 
@@ -17,9 +18,10 @@ namespace KiCWeb.Controllers
         private readonly ICookieService _cookieService;
         private readonly IEmailService _emailService;
         private readonly IConfigurationRoot _configurationRoot;
+        private readonly IBackgroundJobClient _jobClient;
         private KiCdbContext _kdbContext;
 
-        public GenController(IKiCLogger logger, IHttpContextAccessor httpContextAccessor, ICookieService cookieService, IEmailService emailService, IConfigurationRoot configurationRoot, KiCdbContext kiCdbContext, IUserService userService) : base(configurationRoot, userService, httpContextAccessor, kiCdbContext, cookieService)
+        public GenController(IKiCLogger logger, IHttpContextAccessor httpContextAccessor, ICookieService cookieService, IEmailService emailService, IConfigurationRoot configurationRoot, KiCdbContext kiCdbContext, IUserService userService, IBackgroundJobClient jobClient) : base(configurationRoot, userService, httpContextAccessor, kiCdbContext, cookieService)
         {
             _logger = logger;
             _contextAccessor = httpContextAccessor;
@@ -27,6 +29,7 @@ namespace KiCWeb.Controllers
             _emailService = emailService;
             _configurationRoot = configurationRoot;
             _kdbContext = kiCdbContext;
+            _jobClient = jobClient;
         }
 
         [Route("~/Privacy")]
@@ -377,7 +380,7 @@ namespace KiCWeb.Controllers
 
             try
             {
-                _emailService.SendEmail(message);
+                _jobClient.Enqueue(() => _emailService.SendEmail(message));
             }
             catch (Exception ex)
             {

--- a/Helpers/HangfireAuthFilter.cs
+++ b/Helpers/HangfireAuthFilter.cs
@@ -1,0 +1,12 @@
+using KiCData.Services;
+
+namespace KiCWeb.Helpers;
+using Hangfire.Dashboard;
+
+public class HangfireAuthFilter : IDashboardAuthorizationFilter
+{
+    public bool Authorize(DashboardContext context)
+    {
+        return true;
+    }
+}

--- a/KiCWeb.csproj
+++ b/KiCWeb.csproj
@@ -9,6 +9,8 @@
     <Content Remove="Views\People\Index.cshtml" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Hangfire.AspNetCore" Version="1.8.21" />
+    <PackageReference Include="Hangfire.Core" Version="1.8.21" />
     <PackageReference Include="Hangfire.MySqlStorage" Version="2.0.3" />
     <PackageReference Include="KICData" Version="1.4.5" />
     <PackageReference Include="Square" Version="38.1.0" />

--- a/KiCWeb.csproj
+++ b/KiCWeb.csproj
@@ -9,6 +9,7 @@
     <Content Remove="Views\People\Index.cshtml" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Hangfire.MySqlStorage" Version="2.0.3" />
     <PackageReference Include="KICData" Version="1.4.5" />
     <PackageReference Include="Square" Version="38.1.0" />
     <PackageReference Include="MailKit" Version="4.8.0" />
@@ -33,5 +34,8 @@
     <None Include="wwwroot\**\*">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\kicdata\KiCData.csproj" />
   </ItemGroup>  
 </Project>

--- a/KiCWeb.csproj
+++ b/KiCWeb.csproj
@@ -9,7 +9,6 @@
     <Content Remove="Views\People\Index.cshtml" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\kicdata\KiCData.csproj" />
     <PackageReference Include="Hangfire.AspNetCore" Version="1.8.21" />
     <PackageReference Include="Hangfire.Core" Version="1.8.21" />
     <PackageReference Include="Hangfire.MySqlStorage" Version="2.0.3" />

--- a/Program.cs
+++ b/Program.cs
@@ -1,9 +1,10 @@
 using KiCWeb.Configuration;
 using KiCData.Services;
 using KiCData.Models;
-using KiCData.Models.WebModels;
-using Microsoft.Extensions.Logging;
 using Microsoft.EntityFrameworkCore;
+using Hangfire;
+using Hangfire.MySql;
+using KiCWeb.Helpers;
 
 WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
 
@@ -26,19 +27,35 @@ DbContextOptionsBuilder<KiCdbContext> dbOptionsBuilder = new DbContextOptionsBui
 dbOptionsBuilder.UseMySql(config["Database:ConnectionString"], ServerVersion.AutoDetect(config["Database:ConnectionString"]));
 DbContextOptions<KiCdbContext> options = dbOptionsBuilder.Options;
 builder.Services.AddSingleton<KiCdbContext>(new KiCdbContext(options));
-builder.Services.AddSingleton<IEmailService, EmailService>();
+builder.Services.AddSingleton<IEmailService, SESEmailService>();
 builder.Services.AddSingleton<IUserService, UserService>();
 builder.Services.AddSingleton<IHttpContextAccessor, HttpContextAccessor>();
 builder.Services.AddSingleton<ICookieService, CookieService>();
 builder.Services.AddHttpClient();
 builder.Services.AddSingleton<IKiCLogger, KiCLogger>();
-builder.Services.AddHttpClient<IEmailService, EmailService>(client =>
-{
-	client.BaseAddress = new Uri(config["Base Addresses:Mail"]);
-});
+//builder.Services.AddHttpClient<IEmailService, SESEmailService>(client =>
+//{
+//	client.BaseAddress = new Uri(config["Base Addresses:Mail"]);
+//});
 builder.Services.AddSingleton<IPaymentService, PaymentService>();
 builder.Services.AddSingleton<RegistrationSessionService, RegistrationSessionService>();
 builder.Services.AddControllersWithViews();
+builder.Services.AddHangfire((sp, config) =>
+	{
+		var connectionString = sp.GetRequiredService<IConfiguration>()["Database:ConnectionString"];
+		config.UseStorage(
+			new MySqlStorage(
+				connectionString,
+				new MySqlStorageOptions
+				{
+					TablesPrefix = "Hangfire"
+				}
+			)
+		);
+	}
+);
+builder.Services.AddHangfireServer();
+
 var featureFlags = builder.Configuration
     .GetSection("FeatureFlags")
     .Get<FeatureFlags>() ?? new FeatureFlags();
@@ -77,5 +94,19 @@ app.UseAuthorization();
 app.MapControllerRoute(
 	name: "default",
 	pattern: "{controller=Home}/{action=Index}/{id?}");
+if (app.Environment.IsDevelopment())
+{
+	// Allow more relaxed dashboard access if the app is running in dev mode
+	app.UseHangfireDashboard("/hangfire", new DashboardOptions
+	{
+		Authorization = new [] { new HangfireAuthFilter() },
+		IgnoreAntiforgeryToken = true
+	});
+}
+else
+{
+	// Hangfire dashboard only accessible locally in production mode
+	app.UseHangfireDashboard();
+}
 
 app.Run();


### PR DESCRIPTION
The email service for the KiCWeb Package has been replaced with SESEmailService provided in KiCData.

Review the PR in KIC-Events/kicdata for implementation specifics. This PR also introduces hangfire for background task orchestration. AWS SES can be long requests, so they should be ran in the background whenever possible. An example implementation is shown in GenController and ApiController.

## Config changes

This change requires new properties in your environment's `appsettings.json` file. Additionally, it may require changes to your db connection string to support the full hangfire feature set.

Example `appsettings.json` file:
```json
{
    "Database": {
        "Server": "kicweb-db",
        "Port": "3306",
        "Username": "kicweb",
        "Password": "kicweb",
        "Database": "kicweb",
        "ConnectionString": "Server=kicweb-db;Port=3306;Database=kicweb;Username=kicweb;Password=kicweb;Allow User Variables=True"
    },
    "AWS": {
	"AccessKey": "AWS-IAM-Access-key-here",
	"SecretKey": "AWS-IAM-Access-secret-here",
	"Region": "aws-region-identifer"
    },
    "Email Addresses": {
	    "From": "mailer-daemon@kicevents.com",
	    "Archive": "technology@kicevents.com"
    }
}
```

* `Database:ConnectionString` requires `Allow User Variables=True` for hangfire support
* New section `AWS`
* New section `Email Addresses`
  - `From` represents the sender email address to use in SES
  - `Archive` email address is added as a BCC recipient on all outgoing emails

Resolves #235 