### PR TITLE
Refactor inventory handling

### DIFF
--- a/Controllers/CureController.cs
+++ b/Controllers/CureController.cs
@@ -179,7 +179,7 @@ namespace KiCWeb.Controllers
             var ticketInventoryList = ticketInventory;
             foreach (ItemInventory ti in ticketInventoryList)
             {
-                SelectListItem item = new SelectListItem(ti.Name, ti.Name);
+                SelectListItem item = new SelectListItem(ti.Name + " - $" + ti.Price.ToString(), ti.Name);
                 if (ti.QuantityAvailable <= 0)
                 {                 
                     item.Disabled = true;
@@ -226,13 +226,6 @@ namespace KiCWeb.Controllers
             //     return View(registrationData);
             // }
 
-            // If a gold ticket is registered, clear the MealAddon info since it's included with the ticket
-            if ((registrationData.TicketType ?? "").ToLower() == "gold" && registrationData.HasMealAddon)
-            {
-                registrationData.HasMealAddon = false;
-                registrationData.MealAddon = null; // Clear it if it's set (i.e. if editing a ticket from standard->gold)
-            }
-
             if (registrationData.HasMealAddon == true)
             {
                 registrationData.MealAddon = await _paymentService.GetAddonItemAsync();
@@ -256,10 +249,6 @@ namespace KiCWeb.Controllers
                 }
 
                 registrationData.TicketComp = comp;
-            }
-            else
-            {
-                registrationData.TicketComp = null;
             }
 
             if (registrationData.RegId != Guid.Empty)
@@ -461,7 +450,7 @@ namespace KiCWeb.Controllers
                         _logger.LogError(ex.ToString());
                     }
 
-                    return RedirectToAction("carderror");
+                    return RedirectToAction("error");
                 }
 
 

--- a/Controllers/CureController.cs
+++ b/Controllers/CureController.cs
@@ -226,6 +226,13 @@ namespace KiCWeb.Controllers
             //     return View(registrationData);
             // }
 
+            // If a gold ticket is registered, clear the MealAddon info since it's included with the ticket
+            if ((registrationData.TicketType ?? "").ToLower() == "gold" && registrationData.HasMealAddon)
+            {
+                registrationData.HasMealAddon = false;
+                registrationData.MealAddon = null; // Clear it if it's set (i.e. if editing a ticket from standard->gold)
+            }
+
             if (registrationData.HasMealAddon == true)
             {
                 registrationData.MealAddon = await _paymentService.GetAddonItemAsync();

--- a/Controllers/CureController.cs
+++ b/Controllers/CureController.cs
@@ -307,6 +307,8 @@ namespace KiCWeb.Controllers
             if (registrationToRemove != null)
             {
                 registrations.Remove(registrationToRemove);
+                List<RegistrationViewModel> regList = new List<RegistrationViewModel>() { registrationToRemove };
+                _inventoryService.AdjustInventoryAsync(regList, true);
                 _registrationSessionService.Registrations = registrations;
             }
             return NoContent();
@@ -500,6 +502,8 @@ namespace KiCWeb.Controllers
         [Route("carderror")]
         public IActionResult CardError()
         {
+            var regList = _registrationSessionService.Registrations;
+            _inventoryService.AdjustInventoryAsync(regList, true);
             _registrationSessionService.Clear();
             return RedirectToAction("Index");
         }

--- a/Controllers/CureController.cs
+++ b/Controllers/CureController.cs
@@ -3,7 +3,6 @@ using Microsoft.AspNetCore.Mvc;
 using KiCData.Services;
 using KiCData.Models.WebModels;
 using KiCData.Models.WebModels.PaymentModels;
-using KiCData.Models.WebModels.PurchaseModels;
 using KiCData.Models;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
@@ -25,6 +24,7 @@ namespace KiCWeb.Controllers
         private readonly FeatureFlags _featureFlags;
         private readonly ILogger _logger;
         private readonly PaymentService _paymentService;
+        private readonly InventoryService _inventoryService;
         private readonly RegistrationSessionService _registrationSessionService;
         private readonly IConfigurationRoot _configurationRoot;
         private readonly IHttpContextAccessor _contextAccessor;
@@ -103,12 +103,12 @@ namespace KiCWeb.Controllers
         [Route("registration/form")]
         public async Task<IActionResult> RegistrationForm(Guid? regId)
         {
-            List<ItemInventory> ticketInventory;
-            List<ItemInventory> addonInventory;
+            List<InventoryItem> ticketInventory;
+            List<InventoryItem> addonInventory;
             try
             {
-                ticketInventory = await _paymentService.GetItemInventoryAsync("CURE 2026");
-                addonInventory = await _paymentService.GetItemInventoryAsync("Decadent Delight");
+                ticketInventory = await _inventoryService.GetItemInventoryAsync("CURE 2026");
+                addonInventory = await _inventoryService.GetItemInventoryAsync("Decadent Delight");
                 ViewBag.TicketInventory = ticketInventory;
                 ViewBag.Addon = addonInventory.First();
             }
@@ -140,7 +140,7 @@ namespace KiCWeb.Controllers
                     new SelectListItem("Not Staying in Host Hotel", "Not Staying in Host Hotel"),
                 ];
 
-                List<ItemInventory> _addons = addonInventory;
+                List<InventoryItem> _addons = addonInventory;
                 ViewBag.Addon = _addons.First();
                 ViewBag.TicketInventory = ticketInventory;
                 ViewBag.IsUpdating = true;
@@ -177,10 +177,10 @@ namespace KiCWeb.Controllers
 
             registration.TicketTypes = new List<SelectListItem>();
             var ticketInventoryList = ticketInventory;
-            foreach (ItemInventory ti in ticketInventoryList)
+            foreach (InventoryItem ti in ticketInventoryList)
             {
-                SelectListItem item = new SelectListItem(ti.Name + " - $" + ti.Price.ToString(), ti.Name);
-                if (ti.QuantityAvailable <= 0)
+                SelectListItem item = new SelectListItem(ti.Name + " - $" + ti.PriceInDollars.ToString(), ti.Name);
+                if (ti.Stock <= 0)
                 {                 
                     item.Disabled = true;
                     item.Text = ti.Name + " - SOLD OUT";
@@ -197,7 +197,7 @@ namespace KiCWeb.Controllers
               new SelectListItem("Not Staying in Host Hotel", "Not Staying in Host Hotel"),
             ];
 
-            List<ItemInventory> addons = addonInventory;
+            List<InventoryItem> addons = addonInventory;
             ViewBag.Addon = addons.First();
             ViewBag.TicketInventory = ticketInventoryList;
             ViewBag.IsUpdating = false;
@@ -228,10 +228,12 @@ namespace KiCWeb.Controllers
 
             if (registrationData.HasMealAddon == true)
             {
-                registrationData.MealAddon = await _paymentService.GetAddonItemAsync();
+                registrationData.MealAddon = await _inventoryService.GetAddonItemAsync();
             }
 
             var registrations = _registrationSessionService.Registrations;
+
+            _inventoryService.AdjustInventoryAsync(registrations, true);
 
             if (registrationData.DiscountCode is not null)
             {
@@ -270,7 +272,7 @@ namespace KiCWeb.Controllers
             registrationData.RegId = Guid.NewGuid();
 
 
-            registrationData.Price = _paymentService.GetTicketPrice(registrationData.TicketType);
+            registrationData.Price = _inventoryService.GetTicketPrice(registrationData.TicketType);
 
             registrations.Add(registrationData);
             _registrationSessionService.Registrations = registrations;
@@ -321,7 +323,7 @@ namespace KiCWeb.Controllers
         [Route("registration/payment")]
         public async Task<IActionResult> RegistrationPayment()
         {
-            var ticketInventory = _paymentService.GetItemInventoryAsync("CURE 2026");
+            var ticketInventory = _inventoryService.GetItemInventoryAsync("CURE 2026");
 
             if (!_featureFlags.ShowCureRegistration)
             {
@@ -341,12 +343,11 @@ namespace KiCWeb.Controllers
             // Set TicketId to the SquareId, and set the Price
             foreach (RegistrationViewModel r in registrations)
             {
-                foreach (ItemInventory ti in ticketInventoryList)
+                foreach (InventoryItem ti in ticketInventoryList)
                 {
                     if (r.TicketType == ti.Name)
                     {
-                        r.Price = ti.Price;
-                        r.TicketId = ti.SquareId;
+                        r.Price = (double)ti.PriceInDollars;
                     }
                 }
             }
@@ -366,15 +367,15 @@ namespace KiCWeb.Controllers
 
                 if (r.MealAddon is not null)
                 {
-                    priceCheck += r.MealAddon.Price;
-                    r.Price += r.MealAddon.Price;
+                    priceCheck += r.MealAddon.PriceInDollars;
+                    r.Price += (double)r.MealAddon.PriceInDollars;
                 }
             }
 
             if (priceCheck == 0)
             {
                 var attendees = _paymentService.HandleNonPaymentCURETicketOrder(registrations);
-                var orderId = CureRegistrationHelpers.FinalizeTicketOrder(_paymentService, registrations, attendees);
+                var orderId = CureRegistrationHelpers.FinalizeTicketOrder(_inventoryService, _paymentService, registrations, attendees);
                 return RedirectToAction("NoPay");
             }
 
@@ -400,7 +401,7 @@ namespace KiCWeb.Controllers
         [Route("registration/payment")]
         public async Task<IActionResult> RegistrationPayment(CureCardFormModel cfmUpdated)
         {
-            var ticketInventory = _paymentService.GetItemInventoryAsync("CURE 2026");
+            var ticketInventory = _inventoryService.GetItemInventoryAsync("CURE 2026");
 
             Event CureEvent = _kdbContext.Events
                 .Where(e => e.Id == int.Parse(_configurationRoot["CUREID"]))
@@ -412,12 +413,11 @@ namespace KiCWeb.Controllers
             var ticketInventoryList = await ticketInventory;
             foreach (RegistrationViewModel r in cfmUpdated.Items)
             {
-                foreach (ItemInventory ti in ticketInventoryList)
+                foreach (InventoryItem ti in ticketInventoryList)
                 {
                     if (r.TicketType == ti.Name)
                     {
-                        r.Price = ti.Price;
-                        r.TicketId = ti.SquareId;
+                        r.Price = (double)ti.PriceInDollars;
                         r.Event = CureEvent;
                     }
                 }
@@ -457,7 +457,7 @@ namespace KiCWeb.Controllers
                 if (paymentStatus.ToLower() == "approved" || paymentStatus.ToLower() == "completed")
                 {
                     List<RegistrationViewModel> registrationViewModels = _registrationSessionService.Registrations;
-                    var orderId = CureRegistrationHelpers.FinalizeTicketOrder(_paymentService, registrationViewModels, attendees);
+                    var orderId = CureRegistrationHelpers.FinalizeTicketOrder(_inventoryService, _paymentService, registrationViewModels, attendees);
                     CureRegistrationHelpers.UpdateOrderID(_kdbContext, attendees, orderId);
                     return RedirectToAction("cardsuccess");
                 }

--- a/Controllers/CureController.cs
+++ b/Controllers/CureController.cs
@@ -38,7 +38,8 @@ namespace KiCWeb.Controllers
             PaymentService paymentService,
             ILogger<CureController> kiCLogger,
             RegistrationSessionService registrationSessionService,
-            FeatureFlags featureFlags
+            FeatureFlags featureFlags,
+            InventoryService inventoryService
         ) : base(configurationRoot, userService, httpContextAccessor, kiCdbContext, cookieService)
         {
             _kdbContext = kiCdbContext ?? throw new ArgumentNullException(nameof(kiCdbContext));
@@ -48,6 +49,7 @@ namespace KiCWeb.Controllers
             _configurationRoot = configurationRoot ?? throw new ArgumentNullException(nameof(configurationRoot));
             _featureFlags = featureFlags ?? throw new ArgumentNullException(nameof(featureFlags));
             _contextAccessor = httpContextAccessor ?? throw new ArgumentNullException(nameof(httpContextAccessor));
+            _inventoryService = inventoryService ?? throw new ArgumentNullException(nameof(inventoryService));
         }
 
         [Route("")]
@@ -107,8 +109,8 @@ namespace KiCWeb.Controllers
             List<InventoryItem> addonInventory;
             try
             {
-                ticketInventory = await _inventoryService.GetItemInventoryAsync("CURE 2026");
-                addonInventory = await _inventoryService.GetItemInventoryAsync("Decadent Delight");
+                ticketInventory = await _inventoryService.GetItemInventoryAsync("CURE 2026 Ticket");
+                addonInventory = await _inventoryService.GetItemInventoryAsync("CURE 2026 Addon");
                 ViewBag.TicketInventory = ticketInventory;
                 ViewBag.Addon = addonInventory.First();
             }
@@ -401,7 +403,7 @@ namespace KiCWeb.Controllers
         [Route("registration/payment")]
         public async Task<IActionResult> RegistrationPayment(CureCardFormModel cfmUpdated)
         {
-            var ticketInventory = _inventoryService.GetItemInventoryAsync("CURE 2026");
+            var ticketInventory = await _inventoryService.GetItemInventoryAsync("CURE 2026 Ticket");
 
             Event CureEvent = _kdbContext.Events
                 .Where(e => e.Id == int.Parse(_configurationRoot["CUREID"]))
@@ -410,10 +412,9 @@ namespace KiCWeb.Controllers
             // Loop through cfmUpdated.Items (which are the registrations).
             // Match TicketType to ticketInventory[].Name.
             // Set TicketId to the SquareId, and set the Price
-            var ticketInventoryList = await ticketInventory;
             foreach (RegistrationViewModel r in cfmUpdated.Items)
             {
-                foreach (InventoryItem ti in ticketInventoryList)
+                foreach (InventoryItem ti in ticketInventory)
                 {
                     if (r.TicketType == ti.Name)
                     {
@@ -457,7 +458,7 @@ namespace KiCWeb.Controllers
                 if (paymentStatus.ToLower() == "approved" || paymentStatus.ToLower() == "completed")
                 {
                     List<RegistrationViewModel> registrationViewModels = _registrationSessionService.Registrations;
-                    var orderId = CureRegistrationHelpers.FinalizeTicketOrder(_inventoryService, _paymentService, registrationViewModels, attendees);
+                    var orderId = await CureRegistrationHelpers.FinalizeTicketOrder(_inventoryService, _paymentService, registrationViewModels, attendees);
                     CureRegistrationHelpers.UpdateOrderID(_kdbContext, attendees, orderId);
                     return RedirectToAction("cardsuccess");
                 }

--- a/Controllers/Payment.cs
+++ b/Controllers/Payment.cs
@@ -3,6 +3,7 @@ using KiCData.Models.WebModels;
 using KiCData.Services;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.CodeAnalysis.Elfie.Serialization;
 using Newtonsoft.Json;
 using Square.Models;
 
@@ -17,9 +18,10 @@ namespace KiCWeb.Controllers
         private readonly IConfigurationRoot _configurationRoot;
         private readonly KiCdbContext _context;
         private readonly PaymentService _paymentService;
+        private readonly InventoryService _inventoryService;
 	    private KiCdbContext _kdbContext;
 
-        public Payment(ILogger<Payment> logger, IHttpContextAccessor contextAccessor, ICookieService cookieService, IConfigurationRoot configurationRoot, KiCdbContext kiCdbContext, PaymentService paymentService) : base(configurationRoot, userService: null, contextAccessor, kiCdbContext, cookieService)
+        public Payment(ILogger<Payment> logger, IHttpContextAccessor contextAccessor, ICookieService cookieService, IConfigurationRoot configurationRoot, KiCdbContext kiCdbContext, PaymentService paymentService, InventoryService inventoryService) : base(configurationRoot, userService: null, contextAccessor, kiCdbContext, cookieService)
         {
             _logger = logger;
             _contextAccessor = contextAccessor;
@@ -28,6 +30,7 @@ namespace KiCWeb.Controllers
             _context = kiCdbContext;
             _paymentService = paymentService;
             _kdbContext = kiCdbContext;
+            _inventoryService = inventoryService;
         }
 
         [HttpGet("Purchase")]
@@ -74,8 +77,8 @@ namespace KiCWeb.Controllers
                 ViewBag.SalesActive = false;
             }
 
-            int standardCnt = _paymentService.CheckInventory("Blasphemy", "Standard");
-            int vipCnt = _paymentService.CheckInventory("Blasphemy", "VIP");
+            int? standardCnt = _inventoryService.CheckInventory("Blasphemy Standard");
+            int? vipCnt = _inventoryService.CheckInventory("Blasphemy VIP");
 
             ViewBag.StandardCount = standardCnt;
             ViewBag.VIPCount = vipCnt;

--- a/Controllers/SetupController.cs
+++ b/Controllers/SetupController.cs
@@ -1,6 +1,8 @@
 using KiCData.Models;
 using KiCData.Services;
 using Microsoft.AspNetCore.Mvc;
+using Newtonsoft.Json;
+using NuGet.Protocol;
 using Square;
 using Square.Authentication;
 using Square.Exceptions;
@@ -60,9 +62,9 @@ public class SetupController
                 RestockVariants(cureId, 100);
             }
 
-            if (!itemExists("Decadent Delight"))
+            if (!itemExists("Decadent Delights"))
             {
-                _logger.LogText("Creating and stocking 'Decadent Delight' in square catalog.");
+                _logger.LogText("Creating and stocking 'Decadent Delights' in square catalog.");
                 var addonId = CreateAddonCatalogObject();
                 RestockVariants(addonId, 100);
             }
@@ -233,7 +235,7 @@ public class SetupController
             "ITEM",
             "#1",
             presentAtAllLocations: true,
-            itemData: new CatalogItem("Decadent Delight", productType: "REGULAR", variations: addonVariations)
+            itemData: new CatalogItem("Decadent Delights", productType: "REGULAR", variations: addonVariations)
         );
 
         try

--- a/Helpers/CureRegistrationHelpers.cs
+++ b/Helpers/CureRegistrationHelpers.cs
@@ -1,6 +1,5 @@
 using KiCData.Models;
 using KiCData.Models.WebModels;
-using KiCData.Models.WebModels.PurchaseModels;
 using KiCData.Services;
 
 namespace KiCWeb.Helpers;
@@ -44,23 +43,11 @@ public static class CureRegistrationHelpers
         return attendee.Entity;
     }
 
-    public static string? FinalizeTicketOrder(PaymentService paymentService,
+    public static string? FinalizeTicketOrder(InventoryService inventoryService, PaymentService paymentService,
         List<RegistrationViewModel> registrationViewModels, List<Attendee> attendees)
     {
-        List<TicketAddon> ticketAddons = new List<TicketAddon>();
-        foreach (RegistrationViewModel rvm in registrationViewModels)
-        {
-            if (rvm.HasMealAddon == true)
-            {
-                ticketAddons.Add(rvm.MealAddon);
-            }
-        }
         paymentService.SetAttendeesPaid(attendees);
-        paymentService.ReduceTicketInventoryAsync(registrationViewModels);
-        if (ticketAddons.Count > 0)
-        {
-            paymentService.ReduceAddonInventoryAsync(ticketAddons);
-        }
+        inventoryService.AdjustInventoryAsync(registrationViewModels);
 
         return paymentService.getOrderID(registrationViewModels);
     }

--- a/Helpers/CureRegistrationHelpers.cs
+++ b/Helpers/CureRegistrationHelpers.cs
@@ -1,3 +1,4 @@
+using System.Threading.Tasks;
 using KiCData.Models;
 using KiCData.Models.WebModels;
 using KiCData.Services;
@@ -43,11 +44,11 @@ public static class CureRegistrationHelpers
         return attendee.Entity;
     }
 
-    public static string? FinalizeTicketOrder(InventoryService inventoryService, PaymentService paymentService,
+    public static async Task<string?> FinalizeTicketOrder(InventoryService inventoryService, PaymentService paymentService,
         List<RegistrationViewModel> registrationViewModels, List<Attendee> attendees)
     {
         paymentService.SetAttendeesPaid(attendees);
-        inventoryService.AdjustInventoryAsync(registrationViewModels);
+        await inventoryService.AdjustInventoryAsync(registrationViewModels);
 
         return paymentService.getOrderID(registrationViewModels);
     }

--- a/KiCWeb.csproj
+++ b/KiCWeb.csproj
@@ -12,7 +12,6 @@
     <PackageReference Include="Hangfire.AspNetCore" Version="1.8.21" />
     <PackageReference Include="Hangfire.Core" Version="1.8.21" />
     <PackageReference Include="Hangfire.MySqlStorage" Version="2.0.3" />
-    <PackageReference Include="KICData" Version="1.5.3" />
     <PackageReference Include="Square" Version="38.1.0" />
     <PackageReference Include="MailKit" Version="4.8.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.8">
@@ -36,5 +35,8 @@
     <None Include="wwwroot\**\*">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\kicdata\KiCData.csproj" />
   </ItemGroup>  
 </Project>

--- a/KiCWeb.csproj
+++ b/KiCWeb.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="Hangfire.AspNetCore" Version="1.8.21" />
     <PackageReference Include="Hangfire.Core" Version="1.8.21" />
     <PackageReference Include="Hangfire.MySqlStorage" Version="2.0.3" />
+    <PackageReference Include="KICData" Version="1.5.4" />
     <PackageReference Include="Square" Version="38.1.0" />
     <PackageReference Include="MailKit" Version="4.8.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.8">
@@ -35,8 +36,5 @@
     <None Include="wwwroot\**\*">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\kicdata\KiCData.csproj" />
   </ItemGroup>  
 </Project>

--- a/Program.cs
+++ b/Program.cs
@@ -43,6 +43,7 @@ builder.Services.AddSingleton<IKiCLogger, KiCLogger>();
 //});
 builder.Services.AddSingleton<PaymentService, PaymentService>();
 builder.Services.AddSingleton<RegistrationSessionService, RegistrationSessionService>();
+builder.Services.AddSingleton<InventoryService, InventoryService>();
 builder.Services.AddControllersWithViews();
 builder.Services.AddHangfire((sp, config) =>
 	{

--- a/Views/Cure/CardSuccess.cshtml
+++ b/Views/Cure/CardSuccess.cshtml
@@ -1,29 +1,46 @@
+@{
+    ViewBag.Title = "Card Payment Success";
+}
 
-
-<div class="container">
-    <section class="page-section" role="region" aria-labelledby="success-message">
-        <h3>Card Payment Success</h3>
-        <p>Your ticket purchase was successful. Your Order ID is @ViewBag.OrderID.</p>
+<div class="container" style="max-width: 700px; margin: 4rem auto;">
+    <section class="page-section" aria-labelledby="success-message">
+        <div class="info-banner" style="margin-bottom: 2rem;">
+            <h1 id="success-message" class="h2" style="color: var(--color-green); margin-bottom: 1rem;">
+                Card Payment Success
+            </h1>
+            <p>
+                Your ticket purchase was successful.<br />
+                <strong>Your Order ID:</strong> @ViewBag.OrderID
+            </p>
+        </div>
     </section>
-    <section class="page-section" role="region" aria-labelledby="next-steps">
-        <h3>What Comes Next?</h3>
-        <p>You will receive a receipt by email from our payment processor confirming your payment. You will receive another email from <b>mailer-daemon@kicevents.com</b> confirming your ticket purchase and registration details.</p>
-        <p>Our team will manually review the details of your registration and complete a background check before moving on with the registration process. This part of the process may take some time, especially during periods when we are processing many registrations at once.</p>
-        <p>Once the background check is completed, you will receive a final email with instructions on how to contact the host hotel to secure your room for the event.</p>
-        <p><b>You will need to contact the hotel at this point.</b> Reserve your hotel room for <b>both nights</b> of the event.</p>
+    <section class="page-section" aria-labelledby="next-steps">
+        <h2 id="next-steps" class="h5" style="margin-top: 2rem;">What Comes Next?</h2>
+        <p>
+            You will receive an email from <b>mailer-daemon@kicevents.com</b> confirming your ticket purchase and registration details.
+        </p>
+        <p>
+            Our team will manually review the details of your registration and complete a background check before moving on with the registration process. This part of the process may take some time, especially during periods when we are processing many registrations at once.
+        </p>
+        <p>
+            Once the background check is completed, you will receive a final email with instructions on how to contact the host hotel to secure your room for the event.
+        </p>
+        <p>
+            <b>You will need to contact the hotel at this point.</b> Reserve your hotel room for <b>both nights</b> of the event.
+        </p>
     </section>
-    <section class="page-section" role="region" aria-labelledby="external-links">
-        <h3>How Else To Prepare For The Event?</h3>
-        <div class="row">
-            <div class="container col-4">
+    <section class="page-section" aria-labelledby="external-links">
+        <h2 id="external-links" class="h5" style="margin-top: 2rem;">How Else To Prepare For The Event?</h2>
+        <div class="row" style="display: flex; gap: 2rem; justify-content: center;">
+            <div class="container col-4" style="min-width: 180px;">
                 <p><b>Event Merch!</b></p>
-                <a class="button" href="google.com" target="_blank">Merch Store</a>
+                <a class="button" href="https://google.com" target="_blank">Merch Store</a>
             </div>
-            <div class="container col-4">
+            <div class="container col-4" style="min-width: 180px;">
                 <p><b>Join the Discord</b></p>
                 <a class="button" href="https://discord.gg/mRMPabafgc" target="_blank">Discord</a>
             </div>
-            <div class="container col-4">
+            <div class="container col-4" style="min-width: 180px;">
                 <p><b>Join the FetLife Group</b></p>
                 <a class="button" href="https://fetlife.com/groups/315887" target="_blank">FetLife</a>
             </div>

--- a/Views/Cure/RegistrationForm.cshtml
+++ b/Views/Cure/RegistrationForm.cshtml
@@ -224,13 +224,13 @@
       @*Add addon*@
       <div class="field" id="decadent-delights-selection">
         <label asp-for="HasMealAddon"></label>
-        <p>Select here if you would like to add on this Friday VIP exclusive opportunity to mingle with our presenters with a Buffet style dinner. Limited capacity and already included with the Gold Ticket Option. - @ViewBag.AddOn.Price.ToString("C")</p>
-        @if(ViewBag.AddOn.QuantityAvailable > 0){
+        <p>Select here if you would like to add on this Friday VIP exclusive opportunity to mingle with our presenters with a Buffet style dinner. Limited capacity and already included with the Gold Ticket Option. - @ViewBag.AddOn.PriceInDollars.ToString("C")</p>
+        @if(ViewBag.AddOn.Stock > 0){
           <div class="radio">
             <input type="checkbox" name="HasMealAddon" asp-for="HasMealAddon" />
           </div>
         }
-        @if(ViewBag.AddOn.QuantityAvailable == 0){
+        @if(ViewBag.AddOn.Stock == 0){
           <div class="radio">
             <input type="checkbox" name="HasMealAddon" asp-for="HasMealAddon" disabled />
             <span>SOLD OUT</span>

--- a/Views/Cure/RegistrationForm.cshtml
+++ b/Views/Cure/RegistrationForm.cshtml
@@ -207,24 +207,24 @@
         </div>
         @for (int i = 0; i < Model.RoomTypes.Count; i++)
         {
-            var item = Model.RoomTypes[i];
-            <div class="radio">
-              <input
-                type="radio"
-                name="RoomType"
-                id="room_@i"
-                value="@item.Value"
-                asp-for="RoomType"
-              />
-              <label for="room_@i">@item.Text</label>
-            </div>
+          var item = Model.RoomTypes[i];
+          <div class="radio">
+            <input
+              type="radio"
+              name="RoomType"
+              id="room_@i"
+              value="@item.Value"
+              asp-for="RoomType"
+            />
+            <label for="room_@i">@item.Text</label>
+          </div>
         }
       </div>
 
       @*Add addon*@
-      <div class="field">
+      <div class="field" id="decadent-delights-selection">
         <label asp-for="HasMealAddon"></label>
-        <p>Select here if you would like to add on this Friday VIP exclusive opportunity to mingle with our presenters with a Buffet style dinner. Limited capacity and already included with the Gold Ticket Option.</p>
+        <p>Select here if you would like to add on this Friday VIP exclusive opportunity to mingle with our presenters with a Buffet style dinner. Limited capacity and already included with the Gold Ticket Option. - @ViewBag.AddOn.Price.ToString("C")</p>
         @if(ViewBag.AddOn.QuantityAvailable > 0){
           <div class="radio">
             <input type="checkbox" name="HasMealAddon" asp-for="HasMealAddon" />
@@ -236,6 +236,10 @@
             <span>SOLD OUT</span>
           </div>
         }
+      </div>
+      <div class="field hidden" id="decadent-delights-gold">
+        <label asp-for="HasMealAddon"></label>
+        <p>Lucky you. Your gold ticket includes the Decadent Delights add-on. Decadent Delights is an exclusive VIP opportunity to mingle with our presenters with a Buffet style dinner on Friday of the convention.</p>
       </div>
 
       @* If RegId is set, show the "Update" button *@
@@ -252,3 +256,19 @@
     </form>
   </section>
 </div>
+<script type="text/javascript">
+  document.addEventListener('DOMContentLoaded', function(){
+    const ticketDropdown = document.getElementById("TicketType");
+    const addon = document.getElementById("decadent-delights-selection");
+    const goldtext = document.getElementById("decadent-delights-gold");
+    ticketDropdown.addEventListener("change", (event) => {
+      if(ticketDropdown.value.toLowerCase()==="gold") {
+        goldtext.classList.remove("hidden");
+        addon.classList.add("hidden");
+      } else {
+        goldtext.classList.add("hidden");
+        addon.classList.remove("hidden");
+      }
+    });
+  });
+</script>

--- a/Views/Cure/RegistrationPayment.cshtml
+++ b/Views/Cure/RegistrationPayment.cshtml
@@ -94,7 +94,7 @@
 
                 @if (item.HasMealAddon == true)
                 {
-                    decimal mealPrice = (decimal)@item.MealAddon.Price;
+                    decimal mealPrice = (decimal)@item.MealAddon.PriceInDollars;
                     <p>Decadent Delights - @mealPrice.ToString()</p>
                 }
 

--- a/ui/components/form.scss
+++ b/ui/components/form.scss
@@ -303,3 +303,7 @@ form {
     }
   }
 }
+
+.hidden {
+  display: none;
+}


### PR DESCRIPTION
Move inventory tracking off of Square and into our database, which allows us to reserve items during checkout flow. This also greatly simplifies much of the inventory process and reduces the number of Square API calls by a significant amount. 

This is untested, as I would like feedback before I commit changes to the dev DB. 