### PR TITLE
Clean up markup on CURE Presenters page

### DIFF
--- a/Views/Cure/Presenters.cshtml
+++ b/Views/Cure/Presenters.cshtml
@@ -48,27 +48,28 @@
                   @p.Tagline
                 </div>
               }
-              <div class="header-details__class-list">
-                @foreach (var presentation in p.Presentations)
-                {
-                  <div>@presentation.Name</div>
-                }
-              </div>
+              @if (p.Presentations?.Any() == true)
+              {
+                <div class="header-details__class-list">
+                  @foreach (var presentation in p.Presentations)
+                  {
+                    <div>@presentation.Name</div>
+                  }
+                </div>
+              }
               @if (p.Socials?.Any() == true)
               {
                 <div class="header-details__socials">
-                  <div>
-                    <div class="header-details__socials-title">Follow @p.PublicName:</div>
-                    <div class="social-links">
-                      @foreach (var social in p.Socials)
-                      {
-                          if (SocialPlatformMap.Platforms.TryGetValue(social.Platform.ToLower(), out var platform))
-                          {
-                              var fullUrl = platform.UrlPrefix + social.Handle;
-                              @Html.Raw($"""<a href="{fullUrl}" target="_blank" rel="noopener noreferrer">{platform.SvgMarkup}</a>""")
-                          }
-                      }
-                    </div>
+                  <div class="header-details__socials-title">Follow @p.PublicName:</div>
+                  <div class="social-links">
+                    @foreach (var social in p.Socials)
+                    {
+                        if (SocialPlatformMap.Platforms.TryGetValue(social.Platform.ToLower(), out var platform))
+                        {
+                            var fullUrl = platform.UrlPrefix + social.Handle;
+                            @Html.Raw($"""<a href="{fullUrl}" target="_blank" rel="noopener noreferrer">{platform.SvgMarkup}</a>""")
+                        }
+                    }
                   </div>
                 </div>
               }


### PR DESCRIPTION
**Description** 
Clean up markup on CURE Presenters page

**Acceptance criteria**  
- [ ] In the Presenters Dialog, when no classes are present for a presenter, the Class List section should not display
- [ ] In the Presenters Dialog, there should not be an extra `div` wrapping the presenter social media links

**Proposed solution**  
- Conditionally display Class List based on value of `p.Presentations`
- Remove unnecessary wrapper `div` from Social Links